### PR TITLE
Adjust heading level from h1 to h3 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img align="right" src="https://github-readme-stats.vercel.app/api?username=huiyifyj&show_icons=true&bg_color=00000000&hide_title=true&hide_border=true" />
 
-# Hi! 👋
+## Hi! 👋
 
 - 😊 I’m Feng.YJ...
 - 💕 Passionate about open source

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img align="right" src="https://github-readme-stats.vercel.app/api?username=huiyifyj&show_icons=true&bg_color=00000000&hide_title=true&hide_border=true" />
 
-## Hi! 👋
+### Hi! 👋
 
 - 😊 I’m Feng.YJ...
 - 💕 Passionate about open source


### PR DESCRIPTION
Change the heading from `# Hi! 👋` to `### Hi! 👋` to improve document preview.
Page displays grey line (as `<hr>`) below the h1 heading (as in `#`) and this line crosses the right-aligned image, which is not suitable for the title of the document.

![image](https://github.com/user-attachments/assets/b93b7ae4-16a6-4d59-bf86-b6ce6045b21d)
